### PR TITLE
Ensure-Package fixes

### DIFF
--- a/InedoCore/Common/Operations/ProGet/PackageDeployer.cs
+++ b/InedoCore/Common/Operations/ProGet/PackageDeployer.cs
@@ -90,9 +90,19 @@ namespace Inedo.Extensions.Operations.ProGet
                                     continue;
 
                                 if (entry.IsDirectory())
+                                {
                                     expectedDirectories.Add(fullName.Substring("package/".Length).Trim('/'));
+                                }
                                 else
+                                {
                                     expectedFiles.Add(fullName.Substring("package/".Length));
+                                    var parts = fullName.Substring("package/".Length).Split('/');
+                                    for (int i = 1; i < parts.Length; i++)
+                                    {
+                                        // Add directories that are not explicitly in the zip file.
+                                        expectedDirectories.Add(string.Join("/", parts.Take(i)));
+                                    }
+                                }
                             }
                         }
 

--- a/InedoCore/Common/Operations/ProGet/PackageDeployer.cs
+++ b/InedoCore/Common/Operations/ProGet/PackageDeployer.cs
@@ -84,13 +84,15 @@ namespace Inedo.Extensions.Operations.ProGet
                         {
                             foreach (var entry in zip.Entries)
                             {
-                                if (!entry.FullName.StartsWith("package/", StringComparison.OrdinalIgnoreCase) || entry.FullName.Length <= "package/".Length)
+                                // TODO: use AH.ReadZip when it is available in Otter.
+                                var fullName = entry.FullName.Replace('\\', '/');
+                                if (!fullName.StartsWith("package/", StringComparison.OrdinalIgnoreCase) || fullName.Length <= "package/".Length)
                                     continue;
 
                                 if (entry.IsDirectory())
-                                    expectedDirectories.Add(entry.FullName.Substring("package/".Length).Trim('/'));
+                                    expectedDirectories.Add(fullName.Substring("package/".Length).Trim('/'));
                                 else
-                                    expectedFiles.Add(entry.FullName.Substring("package/".Length));
+                                    expectedFiles.Add(fullName.Substring("package/".Length));
                             }
                         }
 


### PR DESCRIPTION
#44 FIX: Ensure-Package does not create directories when upack files are encoded with backslashes in file paths
#45 FIX: Ensure-Package fails when subdirectories are not explicitly listed in the upack archive