### PR TITLE
Add Include/Exclude masking to Ensure-Package operation for Otter drift comparison.

### DIFF
--- a/InedoCore/InedoExtension/Configurations/ProGet/ProGetPackageConfiguration.cs
+++ b/InedoCore/InedoExtension/Configurations/ProGet/ProGetPackageConfiguration.cs
@@ -8,6 +8,7 @@ using Inedo.Extensibility;
 using Inedo.Extensibility.Configurations;
 using Inedo.Extensibility.Credentials;
 using Inedo.Web;
+using System.Collections.Generic;
 
 namespace Inedo.Extensions.Configurations.ProGet
 {
@@ -57,7 +58,16 @@ namespace Inedo.Extensions.Configurations.ProGet
         [DisplayName("Target directory")]
         [Description("The directory path on disk of the package contents.")]
         public string TargetDirectory { get; set; }
-        
+
+        [ScriptAlias("Include")]
+        [PlaceholderText("** (all items)")]
+        [DefaultValue("@(**)")]
+        [MaskingDescription]
+        public IEnumerable<string> Includes { get; set; } = new[] { "**" };
+        [ScriptAlias("Exclude")]
+        [MaskingDescription]
+        public IEnumerable<string> Excludes { get; set; }
+
         [Category("Connection/Identity")]
         [Persistent]
         [ScriptAlias("FeedUrl")]

--- a/InedoCore/InedoExtension/Operations/ProGet/EnsurePackageOperation.Otter.cs
+++ b/InedoCore/InedoExtension/Operations/ProGet/EnsurePackageOperation.Otter.cs
@@ -44,9 +44,11 @@ namespace Inedo.Extensions.Operations.ProGet
                     };
                 }
 
+                var mask = new MaskingContext(this.Template.Includes, this.Template.Excludes);
+
                 this.LogInformation(this.Template.TargetDirectory + " exists; getting remote file list...");
 
-                var remoteFileList = await fileOps.GetFileSystemInfosAsync(this.Template.TargetDirectory, MaskingContext.IncludeAll).ConfigureAwait(false);
+                var remoteFileList = await fileOps.GetFileSystemInfosAsync(this.Template.TargetDirectory, mask).ConfigureAwait(false);
 
                 var remoteFiles = new Dictionary<string, SlimFileSystemInfo>(remoteFileList.Count, StringComparer.OrdinalIgnoreCase);
 
@@ -76,6 +78,11 @@ namespace Inedo.Extensions.Operations.ProGet
                 foreach (var entry in versionInfo.fileList)
                 {
                     var relativeName = entry.name;
+                    if (!mask.IsMatch(relativeName))
+                    {
+                        continue;
+                    }
+
                     var file = remoteFiles.GetValueOrDefault(relativeName);
                     if (file == null)
                     {


### PR DESCRIPTION
Fixes #48.