### PR TITLE
Use built in AD methods to test if user is in group

### DIFF
--- a/InedoCore/InedoExtension/InedoExtension.csproj
+++ b/InedoCore/InedoExtension/InedoExtension.csproj
@@ -59,6 +59,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">

--- a/InedoCore/ProGetExtension/ProGetExtension.csproj
+++ b/InedoCore/ProGetExtension/ProGetExtension.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
+    <Reference Include="System.DirectoryServices.AccountManagement" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
My company recently set up ProGet version 5.0.9 and we were having issues configuring Active Directory groups to task principals. Configuring an Active Directory group caused 90 second delays every 10 minutes or so for all users.

We have 760 Active Directory groups in our company. We also deployed ProGet in AWS. The original code in `GetParentGroups` was making a request for each group. The latency for each request was 120ms resulting in the 90 second delay we were seeing.

Refactoring the method `IsMemberOfGroup` to use built in AD methods to perform this task resulted in no slowdown.

I've built the extension and tested it on our test server running ProGet version 5.0.9 in AWS and the slowdown was eliminated.