### PR TITLE
Improve HTTP operations.

### DIFF
--- a/InedoCore/InedoExtension/InedoExtension.csproj
+++ b/InedoCore/InedoExtension/InedoExtension.csproj
@@ -63,6 +63,9 @@
     <Reference Include="System.Core" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
     <Reference Include="System.Numerics" />
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>

--- a/InedoCore/InedoExtension/Operations/HTTP/HttpOperationBase.cs
+++ b/InedoCore/InedoExtension/Operations/HTTP/HttpOperationBase.cs
@@ -120,7 +120,11 @@ namespace Inedo.Extensions.Operations.HTTP
             if (!string.IsNullOrWhiteSpace(this.UserName))
             {
                 this.LogDebug($"Making request as {this.UserName}...");
-                return new HttpClientHandler { Credentials = new NetworkCredential(this.UserName, this.Password ?? string.Empty) };
+                return new HttpClientHandler
+                {
+                    Credentials = new NetworkCredential(this.UserName, this.Password ?? string.Empty),
+                    PreAuthenticate = true
+                };
             }
 
             return new HttpClientHandler();

--- a/InedoCore/InedoExtension/packages.config
+++ b/InedoCore/InedoExtension/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Inedo.SDK" version="1.0.4" targetFramework="net452" />
   <package id="Inedo.UPack" version="1.0.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Download-Http now reports its progress when running without ProxyRequest: false.
- Upload-Http now reports its progress.
- The ResponseBody output variable now works when ProxyRequest is true.
- Setting MaxResponseLength to a negative number will now read the full response body without truncation.
- Set PreAuthenticate when authenticating to avoid requiring a round trip where HttpClient expects a 401 response.