### PR TITLE
Add @ListSet and %MapSet functions

### DIFF
--- a/InedoCore/InedoExtension/VariableFunctions/Lists/ListSetVariableFunction.cs
+++ b/InedoCore/InedoExtension/VariableFunctions/Lists/ListSetVariableFunction.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.ComponentModel;
+using Inedo.Documentation;
+using Inedo.ExecutionEngine;
+using Inedo.Extensibility;
+using Inedo.Extensibility.VariableFunctions;
+
+namespace Inedo.Extensions.VariableFunctions.Lists
+{
+    [ScriptAlias("ListSet")]
+    [Description("Updates the value at a given position in the list to a new value.")]
+    [Tag("lists")]
+    public sealed class ListSetVariableFunction : VectorVariableFunction
+    {
+        [VariableFunctionParameter(0)]
+        [DisplayName("list")]
+        [Description("The list to update")]
+        public IEnumerable<RuntimeValue>? List { get; set; }
+
+        [VariableFunctionParameter(1)]
+        [DisplayName("index")]
+        [Description("The 0-based index to set.  If negative, counts from the end of the list.  If positive and larger than the list, grows the list as necessary.")]
+        public int Index { get; set; }
+
+        [VariableFunctionParameter(2)]
+        [DisplayName("item")]
+        [Description("The new value")]
+        public RuntimeValue Item { get; set; }
+
+        protected override IEnumerable EvaluateVector(IVariableFunctionContext context)
+        {
+            if (this.List is null) throw new ArgumentNullException(nameof(this.List));
+
+            var list = this.List.ToList();
+            var index = this.Index;
+
+            // bounds checking
+            if (index >= list.Count)
+            {
+                // allow for growing the list to fit new index
+                var empty = RuntimeValue.Default(RuntimeValueType.Scalar);
+                list.AddRange(Enumerable.Range(0, 1+index-list.Count)
+                                        .Select(_ => empty));
+            }
+            else if (index < 0)
+            {
+                // allow for negative indexing from end of array (but not growth)
+                if (-index >= list.Count) throw new ArgumentOutOfRangeException(nameof(this.Index));
+                index = list.Count + (index % list.Count);
+            }
+
+            list[index] = this.Item;
+            return list;
+        }
+    }
+}

--- a/InedoCore/InedoExtension/VariableFunctions/Maps/MapSetVariableFunction.cs
+++ b/InedoCore/InedoExtension/VariableFunctions/Maps/MapSetVariableFunction.cs
@@ -7,7 +7,7 @@ using Inedo.Extensibility.VariableFunctions;
 namespace Inedo.Extensions.VariableFunctions.Maps
 {
     [ScriptAlias("MapSet")]
-    [Description("Adds a key-value pair to a map.")]
+    [Description("Updates the map element with the given key to a new value.  If the existing key does not exist, it is added")]
     [Tag("maps")]
     public sealed class MapSetVariableFunction : VariableFunction
     {
@@ -23,7 +23,7 @@ namespace Inedo.Extensions.VariableFunctions.Maps
 
         [VariableFunctionParameter(2)]
         [DisplayName("value")]
-        [Description("The value to add.")]
+        [Description("The new value.")]
         public RuntimeValue Value { get; set; }
 
         public override RuntimeValue Evaluate(IVariableFunctionContext context)

--- a/InedoCore/InedoExtension/VariableFunctions/Maps/MapSetVariableFunction.cs
+++ b/InedoCore/InedoExtension/VariableFunctions/Maps/MapSetVariableFunction.cs
@@ -1,0 +1,40 @@
+using System.ComponentModel;
+using Inedo.Documentation;
+using Inedo.ExecutionEngine;
+using Inedo.Extensibility;
+using Inedo.Extensibility.VariableFunctions;
+
+namespace Inedo.Extensions.VariableFunctions.Maps
+{
+    [ScriptAlias("MapSet")]
+    [Description("Adds a key-value pair to a map.")]
+    [Tag("maps")]
+    public sealed class MapSetVariableFunction : VariableFunction
+    {
+        [VariableFunctionParameter(0)]
+        [DisplayName("map")]
+        [Description("The map.")]
+        public IDictionary<string, RuntimeValue>? Map { get; set; }
+
+        [VariableFunctionParameter(1)]
+        [DisplayName("key")]
+        [Description("The key to set.")]
+        public string? Key { get; set; }
+
+        [VariableFunctionParameter(2)]
+        [DisplayName("value")]
+        [Description("The value to add.")]
+        public RuntimeValue Value { get; set; }
+
+        public override RuntimeValue Evaluate(IVariableFunctionContext context)
+        {
+            if (this.Map is null) throw new ArgumentNullException(nameof(this.Map));
+            if (String.IsNullOrWhiteSpace(this.Key)) throw new ArgumentNullException(nameof(this.Key));
+
+            var map = new Dictionary<string, RuntimeValue>(this.Map);
+            map[this.Key] = this.Value;
+
+            return new RuntimeValue(map);
+        }
+    }
+}


### PR DESCRIPTION
Allows for overwriting values in existing lists by index, or in existing maps by key; index or key can be supplied by variable.  

Mitigates missing syntax elements `set @list[$i] = something;` and `set %map.$key = something;` by allowing `set @list = @ListSet(@list, $i, something);` and `set %map = %MapSet(%map, $key, something);`.

Discussed in https://forums.inedo.com/topic/4919/suggestion-allow-for-setting-list-or-map-elements-by-dynamic-index-or-key-listset-mapset/4.