### PR TITLE
GenericLDAP: escape search terms and fix getting property value

### DIFF
--- a/InedoCore/InedoExtension/UserDirectories/Clients/NovellLdapClient.cs
+++ b/InedoCore/InedoExtension/UserDirectories/Clients/NovellLdapClient.cs
@@ -144,7 +144,7 @@ internal sealed class NovellLdapClient : LdapClient
         {
             try
             {
-                return this.entry.GetAttributeSet(propertyName)?.FirstOrDefault().Value?.StringValue;
+                return this.entry.GetStringValueOrDefault(propertyName);
             }
             catch
             {

--- a/InedoCore/InedoExtension/UserDirectories/OpenLdap/OpenLdapUserDirectory.cs
+++ b/InedoCore/InedoExtension/UserDirectories/OpenLdap/OpenLdapUserDirectory.cs
@@ -303,7 +303,7 @@ public sealed partial class OpenLdapUserDirectory : UserDirectory
         
         if(searchType.HasFlag(PrincipalSearchType.Users))
         {
-            var userFilter = this.UsersFilter.Replace("%s", searchTerm);
+            var userFilter = this.UsersFilter.Replace("%s", LdapHelperV4.Escape(searchTerm));
             string[] attributes = ["distinguishedName", "objectCategory", "objectClass", this.UserNamePropertyName, this.DisplayNamePropertyName, this.EmailAddressPropertyName];
             var entries = ldapClient.SearchV2Async(this.UserBaseDn, userFilter, LdapClientSearchScope.Subtree, attributes);
             await foreach(var user in entries)
@@ -311,7 +311,7 @@ public sealed partial class OpenLdapUserDirectory : UserDirectory
         }
         if(searchType.HasFlag(PrincipalSearchType.Groups))
         {
-            var groupFilter = this.GroupsFilter.Replace("%s", searchTerm);
+            var groupFilter = this.GroupsFilter.Replace("%s", LdapHelperV4.Escape(searchTerm));
             string[] attributes = ["distinguishedName", "objectCategory", "objectClass", this.GroupNamePropertyName];
             var entries = ldapClient.SearchV2Async(this.GroupBaseDn, groupFilter, LdapClientSearchScope.Subtree, attributes);
             await foreach (var group in entries)
@@ -329,7 +329,7 @@ public sealed partial class OpenLdapUserDirectory : UserDirectory
         using var ldapClient = await this.GetClientAndConnectAsync(true);
         var groups = new HashSet<string>();
 
-        var groupFilter = this.UserGroupsFilter.Replace("%s", principalId.DistinguishedName);
+        var groupFilter = this.UserGroupsFilter.Replace("%s", LdapHelperV4.Escape(principalId.DistinguishedName));
         var groupEntries = ldapClient.SearchV2Async(this.GroupBaseDn, groupFilter, LdapClientSearchScope.Subtree, ["distinguishedName", "objectCategory", "objectClass", this.GroupNamePropertyName]);
         await foreach(var groupEntry in groupEntries)
         {
@@ -349,7 +349,7 @@ public sealed partial class OpenLdapUserDirectory : UserDirectory
     private async IAsyncEnumerable<IUserDirectoryUser> GetMembersAsync(PrincipalId principalId)
     {
         using var ldapClient = await this.GetClientAndConnectAsync(true);
-        var memberFilter = this.GroupMembersFilter.Replace("%s", principalId.DistinguishedName);
+        var memberFilter = this.GroupMembersFilter.Replace("%s", LdapHelperV4.Escape(principalId.DistinguishedName));
 
         var memberEntries = ldapClient.SearchV2Async(this.UserBaseDn, memberFilter, LdapClientSearchScope.Subtree, ["distinguishedName", "objectCategory", "objectClass", this.UserNamePropertyName, this.DisplayNamePropertyName, this.EmailAddressPropertyName]).Select(u => CreatePrincipal(u, true)).OfType<IUserDirectoryUser>();
         await foreach (var e in memberEntries)


### PR DESCRIPTION
Please also see my comment in https://github.com/Inedo/inedox-inedocore/pull/182.

This bug drove me nuts, so I built a small test program using this library to reproduce it. The missing Escape calls are obvious (e.g. cns like `Lastname, Firstname`), but I can’t say for sure whether `GetStringValueOrDefault` still works for all of your use cases. This fixed the usage of `sAMAccountName` in my case.

To test the change i replaced the DLL in the Upack InedoCore file from proget.inedo.com and mounted it inside my container to replace the version there. The scripts here do sth. like that but look like they only work on your laptop(s).

---

As the OpenLDAP connection dialog in ProGet does not have the greatest UX the followings thing was very helpful:

On the VM:
```bash
docker excec -it my-proget-container bash
apt-get update && apt-get install -y ldap-utils
ldapsearch -x -H ldap://ldap.example.com -b "dc=example,dc=com" ...
```

This way i could test all the queries without the nasty ProGet bug and prove that they are indeed correct.

Maybe we can add it to the docs for troubleshooting in containers / non windows and non ad joined devices